### PR TITLE
[JB][OPS-14952]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Example response:
 
 ## Requirements
 
-- Scala 2.13.x
-- Java 11
-- sbt 1.9.x
+- Scala 3.3.7
+- Java 21
+- sbt 1.10.10
 - [Service Manager V2](https://github.com/hmrc/sm2)
 
 ## Running locally

--- a/app/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/FindPaymentController.scala
+++ b/app/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/FindPaymentController.scala
@@ -15,8 +15,9 @@
  */
 
 package uk.gov.hmrc.thirdpartypaymentsexternalapi.controllers
+import play.api.Logging
 import play.api.libs.json.Json
-import play.api.mvc._
+import play.api.mvc.*
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.thirdpartypaymentsexternalapi.config.AppConfig
@@ -34,7 +35,7 @@ class FindPaymentController @Inject() (
   findPaymentService: FindPaymentService,
   appConfig:          AppConfig
 )(implicit executionContext: ExecutionContext)
-    extends BackendController(cc) {
+    extends BackendController(cc) with Logging {
 
   def status(clientJourneyId: ClientJourneyId): Action[AnyContent] = Action.async {
     implicit request: Request[AnyContent] =>
@@ -45,7 +46,9 @@ class FindPaymentController @Inject() (
         .recover { case e: UpstreamErrorResponse =>
           e.statusCode match {
             case 404 => NotFound
-            case _   => InternalServerError
+            case _   =>
+              logger.error(s"Unexpected error (not a 404) from pay-api when looking up a payment status. Error was: [${e.getMessage}]")
+              InternalServerError
           }
         }
   }

--- a/app/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/FindPaymentController.scala
+++ b/app/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/FindPaymentController.scala
@@ -35,7 +35,8 @@ class FindPaymentController @Inject() (
   findPaymentService: FindPaymentService,
   appConfig:          AppConfig
 )(implicit executionContext: ExecutionContext)
-    extends BackendController(cc) with Logging {
+    extends BackendController(cc)
+    with Logging {
 
   def status(clientJourneyId: ClientJourneyId): Action[AnyContent] = Action.async {
     implicit request: Request[AnyContent] =>
@@ -47,7 +48,9 @@ class FindPaymentController @Inject() (
           e.statusCode match {
             case 404 => NotFound
             case _   =>
-              logger.error(s"Unexpected error (not a 404) from open-banking when looking up a payment status. Error was: [${e.getMessage}]")
+              logger.error(
+                s"Unexpected error (not a 404) from open-banking when looking up a payment status. Error was: [${e.getMessage}]"
+              )
               InternalServerError
           }
         }

--- a/app/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/FindPaymentController.scala
+++ b/app/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/FindPaymentController.scala
@@ -47,7 +47,7 @@ class FindPaymentController @Inject() (
           e.statusCode match {
             case 404 => NotFound
             case _   =>
-              logger.error(s"Unexpected error (not a 404) from pay-api when looking up a payment status. Error was: [${e.getMessage}]")
+              logger.error(s"Unexpected error (not a 404) from open-banking when looking up a payment status. Error was: [${e.getMessage}]")
               InternalServerError
           }
         }

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ StrictBuilding.strictBuildingSetting
 //---
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "3.7.4"
+ThisBuild / scalaVersion := "3.3.7"
 
 lazy val microservice = Project("third-party-payments-external-api", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,7 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%highlight(%level)] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%green(%date{ISO8601}) %gray(level=)[%highlight(%5level)] %gray(message=[%yellow(%message)])  %gray(logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}]) %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,12 +3,12 @@ import sbt.*
 //format: OFF
 object AppDependencies {
 
-  private val bootstrapVersion = "10.5.0"
+  private val bootstrapVersion = "10.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"   %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "com.beachape"  %% "enumeratum-play-json"      % "1.9.4",
-    "org.typelevel" %% "cats-effect"               % "3.6.3"
+    "com.beachape"  %% "enumeratum-play-json"      % "1.9.7",
+    "org.typelevel" %% "cats-effect"               % "3.7.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.4.1")
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"    % "3.4.3")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.0")

--- a/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/StartPaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/controllers/StartPaymentControllerSpec.scala
@@ -33,6 +33,8 @@ class StartPaymentControllerSpec extends ItSpec {
 
   private val startPaymentController = app.injector.instanceOf[StartPaymentController]
 
+  override lazy val configOverrides: Map[String, Any] = Map("auditing.enabled" -> true)
+
   private def testThirdPartyRequest(
     taxRegime:     TaxRegime,
     reference:     Reference,

--- a/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/services/AuditServiceSpec.scala
@@ -30,6 +30,8 @@ class AuditServiceSpec extends ItSpec {
 
   val auditService: AuditService = app.injector.instanceOf[AuditService]
 
+  override lazy val configOverrides: Map[String, Any] = Map("auditing.enabled" -> true)
+
   "AuditService" - {
 
     "should successfully send audit when the journey is not successful and Null values" in {

--- a/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/testsupport/ItSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/testsupport/ItSpec.scala
@@ -44,14 +44,17 @@ trait ItSpec
   implicit val ec: ExecutionContext            = scala.concurrent.ExecutionContext.Implicits.global
   implicit lazy val materializer: Materializer = app.materializer
 
+  // hint: override in specific tests to set bespoke config for that test
+  protected lazy val configOverrides: Map[String, Any] = Map()
+  
   protected lazy val configMap: Map[String, Any] = Map[String, Any](
-    "auditing.enabled"                        -> true,
+    "auditing.enabled"                        -> false,
     "auditing.traceRequests"                  -> false,
     "auditing.consumer.baseUri.port"          -> self.wireMockPort,
     "microservice.services.pay-api.port"      -> self.wireMockPort,
     "microservice.services.open-banking.port" -> self.wireMockPort,
     "internal-auth.token"                     -> "wowow"
-  )
+  ) ++ configOverrides
 
   lazy val overridesModule: AbstractModule = new AbstractModule {
     @Provides

--- a/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/testsupport/ItSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartypaymentsexternalapi/testsupport/ItSpec.scala
@@ -46,7 +46,7 @@ trait ItSpec
 
   // hint: override in specific tests to set bespoke config for that test
   protected lazy val configOverrides: Map[String, Any] = Map()
-  
+
   protected lazy val configMap: Map[String, Any] = Map[String, Any](
     "auditing.enabled"                        -> false,
     "auditing.traceRequests"                  -> false,


### PR DESCRIPTION
- downgrade scala version to 3.3.7, anything higher has bugs in string interpolation and it sucks
- add logging statement in FindPaymentController.status to help us see why open banking call may have failed
- dependency updates (play -> 3.0.10, bootstrap -> 10.7.0, enumeratum -> 1.9.7, cats -> 3.7.0)
- update README.md to reflect correct scala version/java version, sbt version
- update ItSpec so we don't have auditing for every test, instead override it when needed as per good practice